### PR TITLE
Run and stream application to android

### DIFF
--- a/cf.log
+++ b/cf.log
@@ -1,0 +1,24 @@
+nohup: ignoring input
+2025-08-09T21:32:00Z INF Thank you for trying Cloudflare Tunnel. Doing so, without a Cloudflare account, is a quick way to experiment and try it out. However, be aware that these account-less Tunnels have no uptime guarantee, are subject to the Cloudflare Online Services Terms of Use (https://www.cloudflare.com/website-terms/), and Cloudflare reserves the right to investigate your use of Tunnels for violations of such terms. If you intend to use Tunnels in production you should use a pre-created named tunnel by following: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps
+2025-08-09T21:32:00Z INF Requesting new quick Tunnel on trycloudflare.com...
+2025-08-09T21:32:03Z INF +--------------------------------------------------------------------------------------------+
+2025-08-09T21:32:03Z INF |  Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):  |
+2025-08-09T21:32:03Z INF |  https://intl-boxing-sub-dumb.trycloudflare.com                                            |
+2025-08-09T21:32:03Z INF +--------------------------------------------------------------------------------------------+
+2025-08-09T21:32:03Z INF Cannot determine default configuration path. No file [config.yml config.yaml] in [~/.cloudflared ~/.cloudflare-warp ~/cloudflare-warp /etc/cloudflared /usr/local/etc/cloudflared]
+2025-08-09T21:32:03Z INF Version 2025.8.0 (Checksum c7d3a69da0f7b9b1bc1ddcb0597d3552bcd7c15f8bbaba463dc489b94b7544ee)
+2025-08-09T21:32:03Z INF GOOS: linux, GOVersion: go1.24.4, GoArch: amd64
+2025-08-09T21:32:03Z INF Settings: map[ha-connections:1 no-autoupdate:true protocol:quic url:http://localhost:19006]
+2025-08-09T21:32:03Z INF Generated Connector ID: 648f45c9-97d1-4933-a090-e5732c913207
+2025-08-09T21:32:03Z INF Initial protocol quic
+2025-08-09T21:32:03Z INF ICMP proxy will use 172.30.0.2 as source for IPv4
+2025-08-09T21:32:03Z INF ICMP proxy will use fe80::802b:38ff:fe3d:bcd0 in zone eth0 as source for IPv6
+2025-08-09T21:32:03Z WRN The user running cloudflared process has a GID (group ID) that is not within ping_group_range. You might need to add that user to a group within that range, or instead update the range to encompass a group the user is already in by modifying /proc/sys/net/ipv4/ping_group_range. Otherwise cloudflared will not be able to ping this network error="Group ID 1000 is not between ping group 1 to 0"
+2025-08-09T21:32:03Z WRN ICMP proxy feature is disabled error="cannot create ICMPv4 proxy: Group ID 1000 is not between ping group 1 to 0 nor ICMPv6 proxy: socket: permission denied"
+2025-08-09T21:32:03Z ERR Cannot determine default origin certificate path. No file cert.pem in [~/.cloudflared ~/.cloudflare-warp ~/cloudflare-warp /etc/cloudflared /usr/local/etc/cloudflared]. You need to specify the origin certificate path by specifying the origincert option in the configuration file, or set TUNNEL_ORIGIN_CERT environment variable originCertPath=
+2025-08-09T21:32:03Z INF ICMP proxy will use 172.30.0.2 as source for IPv4
+2025-08-09T21:32:03Z INF ICMP proxy will use fe80::802b:38ff:fe3d:bcd0 in zone eth0 as source for IPv6
+2025-08-09T21:32:03Z INF Starting metrics server on 127.0.0.1:20241/metrics
+2025-08-09T21:32:03Z INF Tunnel connection curve preferences: [X25519MLKEM768 CurveP256] connIndex=0 event=0 ip=198.41.192.67
+2025/08/09 21:32:03 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 7168 kiB, got: 416 kiB). See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.
+2025-08-09T21:32:03Z INF Registered tunnel connection connIndex=0 connection=e7642a56-6a01-454e-b57e-0c278d92f29b event=0 ip=198.41.192.67 location=sea01 protocol=quic

--- a/expo.log
+++ b/expo.log
@@ -1,0 +1,8 @@
+nohup: ignoring input
+Starting project at /workspace
+Metro is running in CI mode, reloads are disabled. Remove CI=true to enable watch mode.
+Starting Metro Bundler
+Tunnel connected.
+Tunnel ready.
+Waiting on http://localhost:8082
+Logs for your project will appear below.

--- a/expo.log
+++ b/expo.log
@@ -6,3 +6,6 @@ Tunnel connected.
 Tunnel ready.
 Waiting on http://localhost:8082
 Logs for your project will appear below.
+Tunnel connection has been closed. This is often related to intermittent connection problems with the Ngrok servers. Restart the dev server to try connecting to Ngrok again.
+Check the Ngrok status page for outages: https://status.ngrok.com/
+Tunnel connected.

--- a/lt-web.log
+++ b/lt-web.log
@@ -1,2 +1,14 @@
 nohup: ignoring input
 your url is: https://bitter-words-work.loca.lt
+/home/ubuntu/.npm/_npx/75ac80b86e83d4a2/node_modules/localtunnel/bin/lt.js:81
+    throw err;
+    ^
+
+Error: connection refused: localtunnel.me:16159 (check your firewall settings)
+    at Socket.<anonymous> (/home/ubuntu/.npm/_npx/75ac80b86e83d4a2/node_modules/localtunnel/lib/TunnelCluster.js:52:11)
+    at Socket.emit (node:events:518:28)
+    at emitErrorNT (node:internal/streams/destroy:170:8)
+    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
+    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
+
+Node.js v22.16.0

--- a/lt-web.log
+++ b/lt-web.log
@@ -1,0 +1,2 @@
+nohup: ignoring input
+your url is: https://bitter-words-work.loca.lt

--- a/lt.log
+++ b/lt.log
@@ -1,0 +1,2 @@
+nohup: ignoring input
+your url is: https://calm-adults-hear.loca.lt

--- a/lt.log
+++ b/lt.log
@@ -1,2 +1,14 @@
 nohup: ignoring input
 your url is: https://calm-adults-hear.loca.lt
+/home/ubuntu/.npm/_npx/75ac80b86e83d4a2/node_modules/localtunnel/bin/lt.js:81
+    throw err;
+    ^
+
+Error: connection refused: localtunnel.me:22967 (check your firewall settings)
+    at Socket.<anonymous> (/home/ubuntu/.npm/_npx/75ac80b86e83d4a2/node_modules/localtunnel/lib/TunnelCluster.js:52:11)
+    at Socket.emit (node:events:518:28)
+    at emitErrorNT (node:internal/streams/destroy:170:8)
+    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
+    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
+
+Node.js v22.16.0

--- a/web.log
+++ b/web.log
@@ -1,0 +1,6 @@
+nohup: ignoring input
+Starting project at /workspace
+Metro is running in CI mode, reloads are disabled. Remove CI=true to enable watch mode.
+Starting Metro Bundler
+Waiting on http://localhost:19006
+Logs for your project will appear below.


### PR DESCRIPTION
Start Expo app in web mode and expose it via a public tunnel.

This allows the user to access their app from their Android browser, as direct Expo Go tunnel connection attempts were unsuccessful.

---
<a href="https://cursor.com/background-agent?bcId=bc-039ba9ca-f80e-439f-81f5-7755d51a0a83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-039ba9ca-f80e-439f-81f5-7755d51a0a83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

